### PR TITLE
Add two new options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cron_script.sh
 Photos/
 __pycache__
 *.pyc
+.idea

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
                            [--download-videos]
                            [--auto-delete]
                            [--only-print-filenames]
+                           [--folder-structure=({:%Y/%m/%d})]
+                           [--set-exit-datetime]
                            [--smtp-username <smtp_username>]
                            [--smtp-password <smtp_password>]
                            [--smtp-host <smtp_host>]
@@ -95,6 +97,8 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
         --only-print-filenames          Only prints the filenames of all files that
                                         will be downloaded. (Does not download any
                                         files.)
+        --folder-structure              Folder structure. Default is {:%Y/%m/%d}.
+        --set-exit-datetime             Set exif DateTimeOriginal tag if it's missing.
         --smtp-username <smtp_username>
                                         Your SMTP username, for sending email
                                         notifications when two-step authentication

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
                            [--auto-delete]
                            [--only-print-filenames]
                            [--folder-structure=({:%Y/%m/%d})]
-                           [--set-exit-datetime]
+                           [--set-exif-datetime]
                            [--smtp-username <smtp_username>]
                            [--smtp-password <smtp_password>]
                            [--smtp-host <smtp_host>]
@@ -98,7 +98,7 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
                                         will be downloaded. (Does not download any
                                         files.)
         --folder-structure              Folder structure. Default is {:%Y/%m/%d}.
-        --set-exit-datetime             Writing exif DateTimeOriginal tag from file creation date, if it's not exists.
+        --set-exif-datetime             Writing exif DateTimeOriginal tag from file creation date, if it's not exists.
         --smtp-username <smtp_username>
                                         Your SMTP username, for sending email
                                         notifications when two-step authentication

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
                                         will be downloaded. (Does not download any
                                         files.)
         --folder-structure              Folder structure. Default is {:%Y/%m/%d}.
-        --set-exit-datetime             Set exif DateTimeOriginal tag if it's missing.
+        --set-exit-datetime             Writing exif DateTimeOriginal tag from file creation date, if it's not exists.
         --smtp-username <smtp_username>
                                         Your SMTP username, for sending email
                                         notifications when two-step authentication

--- a/download_photos.py
+++ b/download_photos.py
@@ -7,6 +7,7 @@ import socket
 import requests
 import time
 import itertools
+import piexif
 from tqdm import tqdm
 from dateutil.parser import parse
 
@@ -52,7 +53,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               help='Only prints the filenames of all files that will be downloaded. ' + \
                 '(Does not download any files.)',
               is_flag=True)
-
+@click.option('--folder-structure',
+              help='Folder structure (default: {:%Y/%m/%d})',
+              metavar='<folder_structure>',
+              default='{:%Y/%m/%d}')
+@click.option('--set-exif-datetime',
+              help='Set exif DateTimeOriginal tag if it's missing.',
+              is_flag=True)
 @click.option('--smtp-username',
               help='Your SMTP username, for sending email notifications when two-step authentication expires.',
               metavar='<smtp_username>')
@@ -79,7 +86,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 def download(directory, username, password, size, recent, \
     until_found, download_videos, force_size, auto_delete, \
-    only_print_filenames, \
+    only_print_filenames, folder_structure, set_exif_datetime, \
     smtp_username, smtp_password, smtp_host, smtp_port, smtp_no_tls, \
     notification_email):
     """Download all iCloud photos to a local directory"""
@@ -138,7 +145,7 @@ def download(directory, username, password, size, recent, \
 
                 created_date = photo.created
 
-                date_path = '{:%Y/%m/%d}'.format(created_date)
+                date_path = (folder_structure).format(created_date)
                 download_dir = os.path.join(directory, date_path)
 
                 if not os.path.exists(download_dir):
@@ -156,6 +163,11 @@ def download(directory, username, password, size, recent, \
                     print(download_path)
                 else:
                     download_photo(photo, download_path, size, force_size, download_dir, progress_bar)
+
+                if set_exif_datetime \
+                    and photo.filename.lower().endswith(('.jpg', '.jpeg')) \
+                    and not get_datetime(download_path):
+                        set_datetime(download_path, created_date.strftime("%Y:%m:%d %H:%M:%S"))
 
                 if until_found is not None:
                     consecutive_files_found = 0
@@ -186,7 +198,7 @@ def download(directory, username, password, size, recent, \
 
             for media in recently_deleted:
                 created_date = media.created
-                date_path = '{:%Y/%m/%d}'.format(created_date)
+                date_path = (folder_structure).format(created_date)
                 download_dir = os.path.join(directory, date_path)
 
                 filename = filename_with_size(media, size)
@@ -250,6 +262,22 @@ def download_photo(photo, download_path, size, force_size, download_dir, progres
     else:
         tqdm.write("Could not download %s! Maybe try again later." % photo.filename)
 
+def get_datetime(path):
+    try:
+        exif_dict = piexif.load(path)
+        date = exif_dict.get('Exif').get(36867)
+    except:
+        date = None
+    return date
+
+def set_datetime(path, date):
+    try:
+        exif_dict = piexif.load(path)
+        exif_dict.get('Exif')[36867] = date
+        exif_bytes = piexif.dump(exif_dict)
+        piexif.insert(exif_bytes, path)
+    except:
+        return
 
 if __name__ == '__main__':
     download()

--- a/download_photos.py
+++ b/download_photos.py
@@ -273,11 +273,13 @@ def get_datetime(path):
 def set_datetime(path, date):
     try:
         exif_dict = piexif.load(path)
+        exif_dict.get('1st')[306] = date
         exif_dict.get('Exif')[36867] = date
+        exif_dict.get('Exif')[36868] = date
         exif_bytes = piexif.dump(exif_dict)
         piexif.insert(exif_bytes, path)
     except:
-        return
+       return
 
 if __name__ == '__main__':
     download()

--- a/download_photos.py
+++ b/download_photos.py
@@ -58,7 +58,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               metavar='<folder_structure>',
               default='{:%Y/%m/%d}')
 @click.option('--set-exif-datetime',
-              help='Set exif DateTimeOriginal tag if it's missing.',
+              help='Writing exif DateTimeOriginal tag from file creation date, if it\'s not exists. ',
               is_flag=True)
 @click.option('--smtp-username',
               help='Your SMTP username, for sending email notifications when two-step authentication expires.',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 tqdm==4.5.0
 git+https://github.com/picklepete/pyicloud.git#egg=pyicloud
 piexif
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil
 requests
 tqdm==4.5.0
 git+https://github.com/picklepete/pyicloud.git#egg=pyicloud
+piexif


### PR DESCRIPTION
1. Folder structure format. If I want to change the structure of folders, I can specify my format, for example: --folder-structure='{:%Y/%m}'

2. Writing exif DateTimeOriginal tag from file creation date, if it's not exists. Sometimes photos are stored in a photostream from different sources (browser, telegram, viber) and they do not have any metadata. Because of this, there is a difficulty in the correct organization of photos on the computer (for example in Shotwell).