### PR TITLE
Avoid shadowing built-in file() function

### DIFF
--- a/download_photos.py
+++ b/download_photos.py
@@ -230,10 +230,10 @@ def download_photo(photo, download_path, size, force_size, download_dir, progres
             download_url = photo.download(size)
 
             if download_url:
-                with open(download_path, 'wb') as file:
+                with open(download_path, 'wb') as file_obj:
                     for chunk in download_url.iter_content(chunk_size=1024):
                         if chunk:
-                            file.write(chunk)
+                            file_obj.write(chunk)
                 break
 
             else:


### PR DESCRIPTION
I noticed this because of Github's syntax highlighting of that part of the code.

This avoids the use of `file` as variable as this clashes with the built-in `file()` function in Python 2.7.