### PR TITLE
Re-authenticate on PyiCloudAPIResponseError

### DIFF
--- a/download_photos.py
+++ b/download_photos.py
@@ -7,6 +7,7 @@ import socket
 import requests
 import time
 import itertools
+import pyicloud
 from tqdm import tqdm
 from dateutil.parser import parse
 
@@ -165,6 +166,10 @@ def download(directory, username, password, size, recent, \
                 if not only_print_filenames:
                     tqdm.write('Connection failed, retrying after %d seconds...' % WAIT_SECONDS)
                 time.sleep(WAIT_SECONDS)
+            except pyicloud.exceptions.PyiCloudAPIResponseError:
+                if not only_print_filenames:
+                    tqdm.write('Session error, re-authenticating...')
+                icloud.authenticate()
 
         else:
             if not only_print_filenames:


### PR DESCRIPTION
Sometimes when downloading many photos iCloud will
return session errors. Catch these and re-authenticate.

Fixes the "Invalid global session" Traceback.

Fixes #47