### PR TITLE
Avoid to download in the name of the file without the size is found

### DIFF
--- a/download_photos.py
+++ b/download_photos.py
@@ -158,7 +158,9 @@ def download(directory, username, password, size, recent, \
                     os.makedirs(download_dir)
 
                 download_path = local_download_path(photo, size, download_dir)
-                if os.path.isfile(download_path):
+                download_path_without_size = local_download_path(photo, None, download_dir)
+                # add a check if the "simple" name of the file is found if the size is original
+                if os.path.isfile(download_path) or (size =='original' and os.path.isfile(download_path_without_size)):
                     if until_found is not None:
                         consecutive_files_found += 1
                     if not only_print_filenames:
@@ -231,9 +233,17 @@ def filename_with_size(photo, size):
     return photo.filename.encode('utf-8') \
         .decode('ascii', 'ignore').replace('.', '-%s.' % size)
 
-def local_download_path(photo, size, download_dir):
+def filename_without_size(photo):
+    return photo.filename.encode('utf-8') \
+        .decode('ascii', 'ignore')
+
+def local_download_path(photo, size:None, download_dir):
     # Strip any non-ascii characters.
-    filename = filename_with_size(photo, size)
+    if not size is None:
+        filename = filename_with_size(photo, size)
+    else:
+        filename = filename_without_size(photo)
+
     download_path = os.path.join(download_dir, filename)
 
     return download_path


### PR DESCRIPTION
This pull request avoid to download the cloud file if the name of the file is found in the local directory but without the extension of the size. This use case happens when you downloaded the photo directly with photos app (export original files). 
If the --size parameter is Original,  test if the NAME-original.JPG **or NAME.JPG** is found in the local directory, not download the file. 