### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ you can clear a stored password using the `--delete-from-keyring` command-line o
                            [--size=(original|medium|thumb)]
                            [--recent <integer>]
                            [--until-found <integer>]
-                           [--download-videos]
                            [--auto-delete]
                            [--only-print-filenames]
                            [--folder-structure=({:%Y/%m/%d})]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:latest
 RUN set -xe && \
     apk add --update --no-cache python py-pip git && \
     git clone https://github.com/ndbroadbent/icloud_photos_downloader.git && \
-    pip2 install -r icloud_photos_downloader/requirements.txt && \
+    cd icloud_photos_downloader && \
+    pip2 install -r requirements.txt && \
     adduser -D -h /home/user -u 1000 user && \
     rm -fr /var/cache/apk/*
 


### PR DESCRIPTION
Dockerfile is broken because requirements.txt expects you to be inside the project folder.  Changing the path in requirements.txt will break non-docker users, so instead I change directory in the Dockerfile.  Also minor fix to README.md.