### PR TITLE
Multi-threaded downloads and basic caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 .coverage
 htmlcov
 downloaded_photos_cache.p
+downloaded_ids_cache.p

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .idea
 .coverage
 htmlcov
+downloaded_photos_cache.p

--- a/icloudpd/autodelete.py
+++ b/icloudpd/autodelete.py
@@ -6,7 +6,7 @@ from icloudpd.logger import setup_logger
 from icloudpd.paths import local_download_path
 
 
-def autodelete_photos(icloud, folder_structure, directory):
+def autodelete_photos(icloud, folder_structure, directory, downloaded_photos):
     """
     Scans the "Recently Deleted" folder and deletes any matching files
     from the download directory.
@@ -27,3 +27,4 @@ def autodelete_photos(icloud, folder_structure, directory):
             if os.path.exists(path):
                 logger.info("Deleting %s!", path)
                 os.remove(path)
+                downloaded_photos.remove(path)  # remove from cache

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -23,6 +23,8 @@ from icloudpd import exif_datetime
 # Must import the constants object so that we can mock values in tests.
 from icloudpd import constants
 
+from concurrent.futures import ThreadPoolExecutor
+
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
@@ -423,9 +425,10 @@ def main(
             break
 
     # pylint: disable-msg=too-many-nested-blocks
-    for photo in photos_enumerator:
-        # insert call here
-        download_photo(photo)
+    with ThreadPoolExecutor() as executor:
+        for photo in photos_enumerator:
+            executor.submit(download_photo, photo)
+            # download_photo(photo)
 
     if only_print_filenames:
         exit(0)

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -83,21 +83,21 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 @click.option(
     "--force-size",
-    help="Only download the requested size "
-    + "(default: download original if size is not available)",
+    help="Only download the requested size " +
+         "(default: download original if size is not available)",
     is_flag=True,
 )
 @click.option(
     "--auto-delete",
-    help='Scans the "Recently Deleted" folder and deletes any files found in there. '
-    + "(If you restore the photo in iCloud, it will be downloaded again.)",
+    help='Scans the "Recently Deleted" folder and deletes any files found in there. ' +
+         "(If you restore the photo in iCloud, it will be downloaded again.)",
     is_flag=True,
 )
 @click.option(
     "--only-print-filenames",
     help="Only prints the filenames of all files that will be downloaded "
-    "(not including files that are already downloaded.)"
-    + "(Does not download or delete any files.)",
+         "(not including files that are already downloaded.)" +
+         "(Does not download or delete any files.)",
     is_flag=True,
 )
 @click.option(
@@ -216,9 +216,9 @@ def main(
             logger.setLevel(logging.ERROR)
 
     raise_error_on_2sa = (
-        smtp_username is not None
-        or notification_email is not None
-        or notification_script is not None
+        smtp_username is not None or
+        notification_email is not None or
+        notification_script is not None
     )
     try:
         icloud = authenticate(
@@ -298,7 +298,7 @@ def main(
     # Configure the caches, either by loading from disk or creating a new one
 
     def load_cache(cache_file):
-        cache_object = set()  # cache of photos we've already downloaded 
+        cache_object = set()  # cache of photos we've already downloaded
         if os.path.exists(cache_file):
             if clear_cache:
                 os.remove(cache_file)
@@ -413,7 +413,7 @@ def main(
                     logger.set_tqdm_description(
                         "%s already exists." % truncate_middle(download_path, 96)
                     )
-                    add_to_cache(download_path, photo.id) # add to cache so we don't check next time
+                    add_to_cache(download_path, photo.id)  # add to cache so we don't check next time
                 else:
                     if only_print_filenames:
                         print(download_path)
@@ -429,7 +429,7 @@ def main(
 
                         # cache that we downloaded this file
                         if download_result:
-                            add_to_cache(download_path, photo.id) # add to cache so we don't check next time
+                            add_to_cache(download_path, photo.id)  # add to cache so we don't check next time
 
                         if download_result and set_exif_datetime:
                             if photo.filename.lower().endswith((".jpg", ".jpeg")):
@@ -471,7 +471,7 @@ def main(
                                 "%s already exists."
                                 % truncate_middle(lp_download_path, 96)
                             )
-                            add_to_cache(lp_download_path, photo.id) # add to cache so we don't check next time                            
+                            add_to_cache(lp_download_path, photo.id)  # add to cache so we don't check next time
                             break
 
                         truncated_path = truncate_middle(lp_download_path, 96)
@@ -482,7 +482,7 @@ def main(
                         )
                         # add to cache
                         if download_result:
-                            add_to_cache(download_path, photo.id) # add to cache so we don't check next time
+                            add_to_cache(download_path, photo.id)  # add to cache so we don't check next time
 
             break
 
@@ -500,5 +500,5 @@ def main(
     if auto_delete:
         autodelete_photos(icloud, folder_structure, directory)
 
-    ## save the caches
+    # save the caches
     save_caches()

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -315,20 +315,16 @@ def main(
 
     cache_file = "downloaded_photos_cache.p"
     downloaded_photos = load_cache(cache_file)
-    cached_ids_file = "downloaded_ids_cache.p"
-    downloaded_ids = load_cache(cached_ids_file)
+    # cached_ids_file = "downloaded_ids_cache.p"
+    # downloaded_ids = load_cache(cached_ids_file)
 
     def add_to_cache(download_path, photo_id):
         downloaded_photos.add(download_path)
-        downloaded_ids.add(photo_id)
+        # downloaded_ids.add(photo_id)
 
     def save_caches():
         pickle.dump(downloaded_photos, open(cache_file, 'wb'))
-        pickle.dump(downloaded_ids, open(cached_ids_file, 'wb'))
-
-
-    # remove the cached ids from the enumerator
-    photos = filter(lambda photo: photo.id not in downloaded_ids, photos)
+        # pickle.dump(downloaded_ids, open(cached_ids_file, 'wb'))
 
     # Use only ASCII characters in progress bar
     tqdm_kwargs["ascii"] = True

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -29,6 +29,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
+
 @click.command(context_settings=CONTEXT_SETTINGS, options_metavar="<options>")
 @click.argument(
     "directory",

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -480,7 +480,7 @@ def main(
 
     # pylint: disable-msg=too-many-nested-blocks
     with ThreadPoolExecutor() as executor:
-        # register handler to save cache on ctrl-c, also lets you ctrl-c no matter which thread catches it
+        # register handler to save cache on ctrl-c, should let you ctrl-c no matter which thread catches it
         def signal_handler(sig, frame):
             print("\nCtrl-C detected, saving cache and exiting...")
             executor.shutdown(wait=False)


### PR DESCRIPTION
I added a ThreadPoolExecutor to speed up the downloading process - seems to help a lot.  I also added some basic caching to speed up restarting a process that failed partially through.  I have 40k photos in my library that I'm trying to back up, so this has made a big difference so far.

Three issues with this approach:
1) I didn't update the progress bar at all.  It seems to still work fine though, but is kind of random in which file it shows at any given time.
2) Ctrl-C doesn't always work due to all the threads. I tried to fix this a little but if you just hit it a couple times it eventually works so I gave up.
3) Caching only sort of helps, since we still need to hit icloud to get the filename of each file to compare with the cache.  I tried on id as well, but that also requires a network hop so it doesn't speed up as much as possible.  Diving into the pyicloud internals more might show a better thing to cache on but I didn't find it quickly.