### PR TITLE
add check for missing --directory parameters

### DIFF
--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -232,6 +232,7 @@ def main(
         threads_num,
 ):
     """Download all iCloud photos to a local directory"""
+
     logger = setup_logger()
     if only_print_filenames:
         logger.disabled = True
@@ -245,6 +246,11 @@ def main(
             logger.setLevel(logging.INFO)
         elif log_level == "error":
             logger.setLevel(logging.ERROR)
+
+    # check required directory param only if not list albums
+    if not list_albums and not directory:
+        print('--directory or --list-albums are required')
+        sys.exit(2)
 
     raise_error_on_2sa = (
         smtp_username is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,3 +100,20 @@ class CliTestCase(TestCase):
                 ],
             )
             assert result.exit_code == 0
+
+    def test_missing_directory_param(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--username",
+                "jdoe@gmail.com",
+                "--password",
+                "password1",
+                "--recent",
+                "0",
+                "--log-level",
+                "info",
+            ],
+        )
+        assert result.exit_code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import click
 from click.testing import CliRunner
 from icloudpd.base import main
+import shutil
 
 vcr = VCR(decode_compressed_response=True)
 
@@ -100,6 +101,29 @@ class CliTestCase(TestCase):
                 ],
             )
             assert result.exit_code == 0
+
+    def test_missing_directory(self):
+        base_dir = os.path.normpath("tests/fixtures/Photos")
+        if os.path.exists(base_dir):
+            shutil.rmtree(base_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--username",
+                "jdoe@gmail.com",
+                "--password",
+                "password1",
+                "--recent",
+                "0",
+                "--log-level",
+                "info",
+                "-d",
+                base_dir
+            ],
+        )
+        assert result.exit_code == 2
 
     def test_missing_directory_param(self):
         runner = CliRunner()

--- a/tests/test_listing_albums.py
+++ b/tests/test_listing_albums.py
@@ -31,8 +31,6 @@ class ListingAlbumsTestCase(TestCase):
                     "password1",
                     "--list-albums",
                     "--no-progress-bar",
-                    "-d",
-                    "tests/fixtures/Photos",
                 ],
             )
 


### PR DESCRIPTION
Checking that --directory parameter is specified. Related to #175